### PR TITLE
Ported Colorscheme to alacritty,kitty and more

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,3 +55,95 @@ If you'd like this colorscheme in Windows Terminal, paste this into your setting
   ]
 }
 ```
+## Xresources
+You can paste this in your ~/.Xresources or ~/.Xdefaults file for using this
+colorscheme in xterm, urxvt and st(with xresources patch)
+```
+! Hack the box
+*.background:  #1a2332
+*.foreground:  #a4b1cd
+*.cursorColor: #313f55
+
+*.color0:  #000000
+*.color8:  #666666
+*.color1:  #ff3e3e
+*.color9:  #ff8484
+*.color2:  #9fef00
+*.color10: #c5f467
+*.color3:  #ffaf00
+*.color11: #ffcc5c
+*.color4:  #004cff
+*.color12: #5cb2ff
+*.color5:  #9f00ff
+*.color13: #c16cfa
+*.color6:  #2ee7b6
+*.color14: #5cecc6
+*.color7:  #ffffff
+*.color15: #ffffff
+```
+
+## Kitty
+Color scheme adapted for kitty terminal. Paste this in your ~/.config/kitty/kitty.conf file
+```conf
+
+background  #1a2332
+foreground  #a4b1cd
+cursor      #3f8193
+
+color0      #000000
+color8      #666666
+color1      #ff3e3e
+color9      #ff8484
+color2      #9fef00
+color10     #c5f467
+color3      #ffaf00
+color11     #ffcc5c
+color4      #004cff
+color12     #5cb2ff
+color5      #9f00ff
+color13     #c16cfa
+color6      #2ee7b6
+color14     #5cecc6
+color7      #ffffff
+color15     #ffffff
+
+selection_background #313f55
+selection_foreground #ffffff
+```
+
+## Alacritty
+Adaptation of colorscheme for alacritty terminal. Paste this in your ~/.config/alacritty/alacritty.yml
+```yaml
+# Hack the Box
+colors:
+  # Default colors
+  primary:
+    background: '#1a2332'
+    foreground: '#a4b1cd'
+
+  selection:
+    text: '#ffffff'
+    background: '#313f55'
+
+  # Normal colors
+  normal:
+    black:   '#000000'
+    red:     '#ff3e3e'
+    green:   '#9fef00'
+    yellow:  '#ffaf00'
+    blue:    '#004cff'
+    magenta: '#9f00ff'
+    cyan:    '#2ee7b6'
+    white:   '#ffffff'
+
+  # Bright colors
+  bright:
+    black:   '#666666'
+    red:     '#ff8484'
+    green:   '#c5f467'
+    yellow:  '#ffcc5c'
+    blue:    '#5cb2ff'
+    magenta: '#c16cfa'
+    cyan:    '#5cecc6'
+    white:   '#ffffff'
+```


### PR DESCRIPTION
I have been using your Colorscheme in vim for past 2 days and I really like it.
I noticed that you have this ported for windows terminal so I added
support for alacritty, kitty. Also support for xterm and urxvt have
been added since they use Xresource/Xdefaults files